### PR TITLE
reset __lastChildSequence__ on parent hotkey when a child hotkey loses focus

### DIFF
--- a/lib/HotKeys.js
+++ b/lib/HotKeys.js
@@ -154,6 +154,9 @@ const HotKeys = React.createClass({
     if (this.props.onBlur) {
       this.props.onBlur(...arguments);
     }
+    if (this.context.hotKeyParent) {
+      this.context.hotKeyParent.childHandledSequence(null);
+    }
   },
 
   render() {


### PR DESCRIPTION
this is for #21 
