### PR TITLE
Updates to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,8 +3,8 @@ import { Component, Props } from 'react';
 interface HotKeysProps extends Props<HotKeys> {
   onFocus?: Function;
   onBlur?: Function;
-  keyMap?: Object;
-  handlers?: Object;
+  keyMap?: {[event: string]: string};
+  handlers?: {[event: string]: Function};
   focused?: boolean;
   attach?: any;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import { Component, Props } from 'react';
 interface HotKeysProps extends Props<HotKeys> {
   onFocus?: Function;
   onBlur?: Function;
-  keyMap?: {[event: string]: string};
+  keyMap?: {[event: string]: string|string[]};
   handlers?: {[event: string]: Function};
   focused?: boolean;
   attach?: any;


### PR DESCRIPTION
Restrict actual key/value types for `keyMap` and `handlers` rather than just `Object`