### PR TITLE
Prevent FocusTrap from being selectable by default.

### DIFF
--- a/lib/FocusTrap.js
+++ b/lib/FocusTrap.js
@@ -23,7 +23,7 @@ const FocusTrap = React.createClass({
     } = this.props;
 
     return (
-      <Component tabIndex="-1" {...props}>
+      <Component tabIndex="-1" style={{ outline: 'none' }} {...props}>
         {children}
       </Component>
     );


### PR DESCRIPTION
There is a blue ring when selecting the wrapper element - which is probably not desirable in most cases.