### PR TITLE
Allow developers to target the tabIndex="-1" in CSS more easily.

### DIFF
--- a/lib/FocusTrap.js
+++ b/lib/FocusTrap.js
@@ -23,7 +23,7 @@ const FocusTrap = React.createClass({
     } = this.props;
 
     return (
-      <Component tabIndex="-1" {...props}>
+      <Component className="FocusTrap" tabIndex="-1" {...props}>
         {children}
       </Component>
     );


### PR DESCRIPTION
Prevent odd blue box issues with styles.
