### PR TITLE
Update TypeScript interface for HotKeys

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ interface HotKeysProps extends HTMLProps<HotKeys> {
   handlers?: Object;
   focused?: boolean;
   attach?: any;
+  component?: any;
 }
 
 export class HotKeys extends Component<HotKeysProps, {}> { }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,6 @@
-import { Component, Props } from 'react';
+import { Component, HTMLProps } from 'react';
 
-interface HotKeysProps extends Props<HotKeys> {
-  onFocus?: Function;
-  onBlur?: Function;
+interface HotKeysProps extends HTMLProps<HotKeys> {
   keyMap?: Object;
   handlers?: Object;
   focused?: boolean;


### PR DESCRIPTION
This change should allow users to set props like 'className' on HotKeys components without TypeScript generating errors.

I'm not 100% sure about these changes, but I've tested this locally and it seems to be working fine.