### PR TITLE
Remove lodash

### DIFF
--- a/examples/master/index.js
+++ b/examples/master/index.js
@@ -1,7 +1,7 @@
 import {HotKeys, HotKeyMapMixin} from 'react-hotkeys';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import rand from 'lodash/number/random';
+import rand from 'lodash/random';
 
 const DEFAULT_NODE_SIZE = 100;
 const SIZE_INCREMENT = 5;

--- a/lib/HotKeyMapMixin.js
+++ b/lib/HotKeyMapMixin.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import assign from 'lodash/assign';
-import isEqual from 'lodash/isEqual';
+import assign from './assign';
+import isEqual from './isEqual';
 
 export default function HotKeyMapMixin(hotKeyMap = {}) {
 

--- a/lib/HotKeys.js
+++ b/lib/HotKeys.js
@@ -4,11 +4,11 @@ import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import FocusTrap from './FocusTrap';
 import HotKeyMapMixin from './HotKeyMapMixin';
-import isBool from 'lodash/isBoolean';
-import isArray from 'lodash/isArray';
-import isObject from 'lodash/isObject';
-import forEach from 'lodash/forEach';
-import isEqual from 'lodash/isEqual';
+import isBool from './isBoolean';
+import isArray from './isArray';
+import isObject from './isObject';
+import forEach from './forEach';
+import isEqual from './isEqual';
 
 function getSequencesFromMap(hotKeyMap, hotKeyName) {
   const sequences = hotKeyMap[hotKeyName];

--- a/lib/assign.js
+++ b/lib/assign.js
@@ -1,0 +1,19 @@
+// Object.assign polyfill from
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+export default function (target, varArgs) { // .length of function is 2
+  let to = Object(target);
+
+  for (let index = 1; index < arguments.length; index++) {
+    let nextSource = arguments[index];
+
+    if (nextSource !== null) { // Skip over if undefined or null
+      for (let nextKey in nextSource) {
+        // Avoid bugs when hasOwnProperty is shadowed
+        if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+          to[nextKey] = nextSource[nextKey];
+        }
+      }
+    }
+  }
+  return to;
+}

--- a/lib/forEach.js
+++ b/lib/forEach.js
@@ -1,0 +1,11 @@
+import isArray from './isArray';
+
+export default (iterable, callback) => {
+  if (isArray(iterable)) {
+    iterable.forEach(callback);
+  } else { // object
+    Object.keys(iterable).forEach(key => {
+      callback(iterable[key], key);
+    });
+  }
+};

--- a/lib/isArray.js
+++ b/lib/isArray.js
@@ -1,0 +1,1 @@
+export default arr => Array.isArray(arr);

--- a/lib/isBoolean.js
+++ b/lib/isBoolean.js
@@ -1,0 +1,1 @@
+export default bool => typeof bool === 'boolean';

--- a/lib/isEqual.js
+++ b/lib/isEqual.js
@@ -1,0 +1,23 @@
+export default (obj1, obj2) => {
+  if (typeof obj1 !== typeof obj2) {
+    return false;
+  }
+  if (obj1 && !obj2) {
+    return false;
+  }
+  if (!obj1 && obj2) {
+    return false;
+  }
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+  if (keys1.length !== keys2.length) {
+    return false;
+  }
+  for (let i = 0; i < keys1.length; i++) {
+    let key1 = keys1[i];
+    if (!(key1 in obj2) || obj2[key1] !== obj1[key1]) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/lib/isObject.js
+++ b/lib/isObject.js
@@ -1,0 +1,1 @@
+export default obj => ((typeof obj === 'object' || typeof obj === 'function') && obj !== null);


### PR DESCRIPTION
Lodash is currently taking up a large part of the bundle size of this library. By removing it, this PR reduces the size of `react-hotkeys.min.js` from 37.4 kB (37389) to 20.7 kB (20742)